### PR TITLE
Resolved mismatch stubbings in AddCommentTest.java

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/jiraext/view/AddCommentTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jiraext/view/AddCommentTest.java
@@ -118,6 +118,7 @@ public class AddCommentTest
         jiraCommits.add(new JiraCommit("SSD-102", MockChangeLogUtil.mockChangeLogSetEntry("Test Comment")));
         doThrow(new RuntimeException("Issue is invalid"))
                 .when(jiraClientSvc).addCommentToTicket("SSD-101", "Test Comment");
+        doNothing().when(jiraClientSvc).addCommentToTicket("SSD-102", "Test Comment");
         addComment.perform(jiraCommits, mockBuild, mock(Launcher.class), new StreamBuildListener(System.out, Charset.defaultCharset()));
         verify(jiraClientSvc, times(1)).addCommentToTicket("SSD-101", "Test Comment");
         verify(jiraClientSvc, times(1)).addCommentToTicket("SSD-102", "Test Comment");


### PR DESCRIPTION
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In the test `testResiliency`: 
* the `addCommentToTicket` method for the `jiraClientSvc` object:
i) during test execution the method is actually called with arguments `["SSD-102", "Test Comment"]`, but is not stubbed, resulting in a mismatch stubbing. 

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.