### PR TITLE
Resolved mismatch stubbings in AddFixVersionTest.java

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/jiraext/view/AddFixVersionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jiraext/view/AddFixVersionTest.java
@@ -121,6 +121,7 @@ public class AddFixVersionTest
 
         doThrow(new RuntimeException("Issue is invalid"))
                 .when(jiraClientSvc).addFixVersion("SSD-101", "Beta Release");
+        doNothing().when(jiraClientSvc).addFixVersion("SSD-102", "Beta Release");
         addFixVersion.perform(jiraCommits, mockBuild, mock(Launcher.class), new StreamBuildListener(System.out, Charset.defaultCharset()));
         // no exception - good!
 


### PR DESCRIPTION
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In the test `testResiliency`: 
* the `addFixVersion` method for the `jiraClientSvc` object:
i) during test execution the method is actually called with arguments `["SSD-102", "Beta Release"]`, but is not stubbed, resulting in a mismatch stubbing. 

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.