### PR TITLE
Resolved mismatch stubbings in AddLabelTest.java

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/jiraext/view/AddLabelTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jiraext/view/AddLabelTest.java
@@ -121,6 +121,7 @@ public class AddLabelTest
         jiraCommits.add(new JiraCommit("SSD-102", MockChangeLogUtil.mockChangeLogSetEntry("Test Comment")));
         doThrow(new RuntimeException("Issue is invalid"))
                 .when(jiraClientSvc).addLabelToTicket("SSD-101", "Test Label");
+        doNothing().when(jiraClientSvc).addLabelToTicket("SSD-102", "Test Label");
         addLabel.perform(jiraCommits, mockBuild, mock(Launcher.class), new StreamBuildListener(System.out, Charset.defaultCharset()));
         verify(jiraClientSvc, times(1)).addLabelToTicket(eq("SSD-101"), eq("Test Label"));
         verify(jiraClientSvc, times(1)).addLabelToTicket(eq("SSD-102"), eq("Test Label"));


### PR DESCRIPTION
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In the test `testResiliency`: 
* the `addLabelToTicket` method for the `jiraClientSvc` object:
i) during test execution the method is actually called with arguments `["SSD-102", "Test Label"]`, but is not stubbed, resulting in a mismatch stubbing. 

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.