### PR TITLE
Resolved mismatch stubbings in AddLabelToFieldTest.java

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/jiraext/view/AddLabelToFieldTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jiraext/view/AddLabelToFieldTest.java
@@ -116,6 +116,7 @@ public class AddLabelToFieldTest {
         jiraCommits.add(new JiraCommit("SSD-102", MockChangeLogUtil.mockChangeLogSetEntry("Test Comment")));
         doThrow(new RuntimeException("Issue is invalid"))
                 .when(jiraClientSvc).addLabelToField(eq("SSD-101"), eq("CustomField_123"), eq("Completed"));
+        doNothing().when(jiraClientSvc).addLabelToField("SSD-102", "CustomField_123", "Completed");
         addLabelToField.perform(jiraCommits, mockBuild, mock(Launcher.class), new StreamBuildListener(System.out, Charset.defaultCharset()));
         verify(jiraClientSvc, times(1)).addLabelToField(eq("SSD-101"), eq("CustomField_123"), eq("Completed"));
         verify(jiraClientSvc, times(1)).addLabelToField(eq("SSD-102"), eq("CustomField_123"), eq("Completed"));


### PR DESCRIPTION
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In the test `testResiliency`: 
* the `addLabelToField` method for the `jiraClientSvc` object:
i) during test execution the method is actually called with arguments `["SSD-102", "CustomField_123", "Completed"]`, but is not stubbed, resulting in a mismatch stubbing. 

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.