### PR TITLE
Resolved mismatch stubbings in UpdateFieldTest.java

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/jiraext/view/UpdateFieldTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jiraext/view/UpdateFieldTest.java
@@ -119,6 +119,7 @@ public class UpdateFieldTest
         jiraCommits.add(new JiraCommit("SSD-102", MockChangeLogUtil.mockChangeLogSetEntry("Test Comment")));
         doThrow(new RuntimeException("Issue is invalid"))
                 .when(jiraClientSvc).updateStringField(eq("SSD-101"), eq("CustomField_123"), eq("Completed"));
+        doNothing().when(jiraClientSvc).updateStringField("SSD-102","CustomField_123", "Completed");
         updateField.perform(jiraCommits, mockBuild, mock(Launcher.class), new StreamBuildListener(System.out, Charset.defaultCharset()));
         verify(jiraClientSvc, times(1)).updateStringField(eq("SSD-101"), eq("CustomField_123"), eq("Completed"));
         verify(jiraClientSvc, times(1)).updateStringField(eq("SSD-102"), eq("CustomField_123"), eq("Completed"));


### PR DESCRIPTION
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In the test `testResiliency`: 
* the `updateStringField` method for the `jiraClientSvc` object:
i) during test execution the method is actually called with arguments `["SSD-102", "CustomField_123", "Completed"]`, but is not stubbed, resulting in a mismatch stubbing. 

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.