### PR TITLE
Resolved mismatch stubbings in TransitionTest.java

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/jiraext/view/TransitionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jiraext/view/TransitionTest.java
@@ -101,7 +101,8 @@ public class TransitionTest
         jiraCommits.add(new JiraCommit("SSD-101", MockChangeLogUtil.mockChangeLogSetEntry("Test Comment")));
         jiraCommits.add(new JiraCommit("SSD-102", MockChangeLogUtil.mockChangeLogSetEntry("Test Comment")));
         doThrow(new RuntimeException("Issue is invalid"))
-                .when(jiraClientSvc).changeWorkflowOfTicket("SSD-101", "Test Comment");
+                .when(jiraClientSvc).changeWorkflowOfTicket("SSD-101", "Resolve");
+        doNothing().when(jiraClientSvc).changeWorkflowOfTicket("SSD-102", "Resolve");
         transition.perform(jiraCommits, mockBuild, mock(Launcher.class), new StreamBuildListener(System.out, Charset.defaultCharset()));
         verify(jiraClientSvc, times(1)).changeWorkflowOfTicket(eq("SSD-101"), eq("Resolve"));
         verify(jiraClientSvc, times(1)).changeWorkflowOfTicket(eq("SSD-102"), eq("Resolve"));


### PR DESCRIPTION
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In the test `testResiliency`:

* The `changeWorkflowOfTicket` method for the `jiraClientSvc` object:
i) is stubbed with arguments `["SSD-101", "Test Comment"]`
ii) during test execution the method is actually called with arguments `["SSD-101", "Resolve"]`, resulting in a mismatch stubbing
iii) during test execution the method is actually called with arguments `["SSD-102", "Resolve"]`, but is not stubbed, resulting in another mismatch stubbing

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.